### PR TITLE
Add test cases to verify that the regular expressions handle unusual whitespace

### DIFF
--- a/testdata/shortcodes.md
+++ b/testdata/shortcodes.md
@@ -75,7 +75,37 @@ The unsplash shortcode:
 
 Another unsplash shortcode:
 
-{{% unsplash 
-  name="xxx" 
-  href="xxx" 
+{{% unsplash
+  name="xxx"
+  href="xxx"
 %}}
+
+Shortcodes with unusual whitespace:
+
+- {{<myshortcode>}}
+- {{< myshortcode>}}
+- {{<  myshortcode>}}
+- {{<myshortcode >}}
+- {{<myshortcode  >}}
+- {{</myshortcode>}}
+- {{< /myshortcode>}}
+- {{<  /myshortcode>}}
+- {{</myshortcode >}}
+- {{</myshortcode  >}}
+- {{%myshortcode%}}
+- {{% myshortcode%}}
+- {{%  myshortcode%}}
+- {{%myshortcode %}}
+- {{%myshortcode  %}}
+- {{%/myshortcode%}}
+- {{% /myshortcode%}}
+- {{%  /myshortcode%}}
+- {{%/myshortcode %}}
+- {{%/myshortcode  %}}
+
+Note that commented shortcodes still require a space after the opening but not necessarily before the closing marker.
+
+- {{</* commentedoutshortcode*/>}}
+- {{</* /closecommentedoutshortcode*/>}}
+- {{%/* commentedoutshortcodemd*/%}}
+- {{%/* /closecommentedoutshortcodemd*/%}}

--- a/testdata/shortcodes.md
+++ b/testdata/shortcodes.md
@@ -69,11 +69,11 @@ For example:
 - {{%/* commentedoutshortcodemd */%}}
 - {{%/* /closecommentedoutshortcodemd */%}}
 
-The unspalsh shortcode:
+The unsplash shortcode:
 
 {{% unsplash name="xxx" href="xxx" %}}
 
-Another unspalsh shortcode:
+Another unsplash shortcode:
 
 {{% unsplash 
   name="xxx" 

--- a/testdata/test.ct
+++ b/testdata/test.ct
@@ -16,7 +16,7 @@ shortcodes.md:58:1:Vale.Spelling:Did you really mean 'Shortcodes'?
 shortcodes.md:60:1:Vale.Spelling:Did you really mean 'Shortcodes'?
 shortcodes.md:62:1:Vale.Spelling:Did you really mean 'Shortcodes'?
 shortcodes.md:64:11:Vale.Spelling:Did you really mean 'shortcodes'?
-shortcodes.md:72:5:Vale.Spelling:Did you really mean 'unspalsh'?
+shortcodes.md:72:5:Vale.Spelling:Did you really mean 'unsplash'?
 shortcodes.md:72:14:Vale.Spelling:Did you really mean 'shortcode'?
-shortcodes.md:76:9:Vale.Spelling:Did you really mean 'unspalsh'?
+shortcodes.md:76:9:Vale.Spelling:Did you really mean 'unsplash'?
 shortcodes.md:76:18:Vale.Spelling:Did you really mean 'shortcode'?

--- a/testdata/test.ct
+++ b/testdata/test.ct
@@ -20,3 +20,6 @@ shortcodes.md:72:5:Vale.Spelling:Did you really mean 'unsplash'?
 shortcodes.md:72:14:Vale.Spelling:Did you really mean 'shortcode'?
 shortcodes.md:76:9:Vale.Spelling:Did you really mean 'unsplash'?
 shortcodes.md:76:18:Vale.Spelling:Did you really mean 'shortcode'?
+shortcodes.md:78:5:Vale.Spelling:Did you really mean 'unsplash'?
+shortcodes.md:83:1:Vale.Spelling:Did you really mean 'Shortcodes'?
+shortcodes.md:106:21:Vale.Spelling:Did you really mean 'shortcodes'?


### PR DESCRIPTION
It turns out I saw problems because I was using the v0.2.0 release but I thought adding these test cases wouldn't hurt.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>